### PR TITLE
refactor: kpm: memory management migrate to sukisu side

### DIFF
--- a/kernel/patch/sukisu/sukisu.c
+++ b/kernel/patch/sukisu/sukisu.c
@@ -67,58 +67,14 @@
 #include <accctl.h>
 #include <kstorage.h>
 
-static long call_buildtime(char __user *out_buildtime, int u_len)
+static long call_kpm_control(const char *name, const char * args, long arg_len, void *__user out_msg, int outlen)
 {
-    const char *buildtime = get_build_time();
-    int len = strlen(buildtime);
-    if (len >= u_len) return -ENOMEM;
-    int rc = compat_copy_to_user(out_buildtime, buildtime, len + 1);
-    return rc;
+    return module_control0(name, arg_len <= 0 ? 0 : args, out_msg, outlen);
 }
 
-static long call_kpm_control(const char __user *arg1, const char *__user arg2, void *__user out_msg, int outlen)
+static long call_kpm_list(char * buf, int len)
 {
-    char name[KPM_NAME_LEN], args[KPM_ARGS_LEN];
-    long namelen = compat_strncpy_from_user(name, arg1, sizeof(name));
-    if (namelen <= 0) return -EINVAL;
-    long arglen = compat_strncpy_from_user(args, arg2, sizeof(args));
-    return module_control0(name, arglen <= 0 ? 0 : args, out_msg, outlen);
-}
-
-static long call_kpm_unload(const char *__user arg1, void *__user reserved)
-{
-    char name[KPM_NAME_LEN];
-    long len = compat_strncpy_from_user(name, arg1, sizeof(name));
-    if (len <= 0) return -EINVAL;
-    return unload_module(name, reserved);
-}
-
-static long call_kpm_nums()
-{
-    return get_module_nums();
-}
-
-static long call_kpm_list(char *__user names, int len)
-{
-    if (len <= 0) return -EINVAL;
-    char buf[4096];
-    int sz = list_modules(buf, sizeof(buf));
-    if (sz > len) return -ENOBUFS;
-    sz = compat_copy_to_user(names, buf, len);
-    return sz;
-}
-
-static long call_kpm_info(const char *__user uname, char *__user out_info, int out_len)
-{
-    if (out_len <= 0) return -EINVAL;
-    char name[64];
-    char buf[2048];
-    int len = compat_strncpy_from_user(name, uname, sizeof(name));
-    if (len <= 0) return -EINVAL;
-    int sz = get_module_info(name, buf, sizeof(buf));
-    if (sz < 0) return sz;
-    if (sz > out_len) return -ENOBUFS;
-    sz = compat_copy_to_user(out_info, buf, sz);
+    int sz = list_modules(buf, len);
     return sz;
 }
 
@@ -128,85 +84,66 @@ void before_sukisu_load_module_path(hook_fargs4_t* args, void* udata) {
     const char* path = (const char*) args->arg0;
     const char* arg = (const char*) args->arg1;
     void* ptr = (void*) args->arg2;
-    void __user* result = (void*) args->arg3;
+    int* result = (void*) args->arg3;
 
     logkfi("Load KPM: %s", path);
 
-    int res = (int) load_module_path(path, arg, ptr);
-    compat_copy_to_user(result, &res, sizeof(res));
+    *result = (int) load_module_path(path, arg, ptr);
     args->skip_origin = 1;
 }
 
 void before_sukisu_unload_module(hook_fargs3_t* args,void* udata) {
     const char* name = (const char*)args->arg0;
     void* ptr = (void*) args->arg1;
-    void __user* result = (void*) args->arg2;
-    int res = (int) unload_module(name, ptr);
-
-    compat_copy_to_user(result, &res, sizeof(res));
+    int* result = (void*) args->arg2;
+    *result = (int) unload_module(name, ptr);
     args->skip_origin = 1;
 }
 
 void before_sukisu_kpm_num(hook_fargs1_t* args, void* udata) {
-    void __user* result = (void*) args->arg0;
+    int* result = (void*) args->arg0;
 
-    int res = (int) get_module_nums();
-    compat_copy_to_user(result, &res, sizeof(res));
+    *result = (int) get_module_nums();
     args->skip_origin = 1;
 }
 
 void before_sukisu_kpm_list(hook_fargs3_t* args, void* udata) {
-    char* __user out = (char* __user) args->arg0;
+    char* out = (char* __user) args->arg0;
     int len = (int) args->arg1;
-    void __user* result = (void*) args->arg2;
+    int * result = (void*) args->arg2;
 
     int res = (int) call_kpm_list(out, len);
     
-    compat_copy_to_user(result, &res, sizeof(res));
+    *result = res;
     args->skip_origin = 1;
 }
 
 void before_sukisu_kpm_info(hook_fargs3_t* args, void* udata) {
     char* name = (char*) args->arg0;
-    char* __user out = (char* __user) args->arg1;
-    void __user* result = (void*) args->arg2;
-    char buf[256];
-    int sz = get_module_info(name, buf, sizeof(buf));
-
-    sz = compat_copy_to_user(out, buf, sz);
-    int res = (int) sz;
-
-    compat_copy_to_user(result, &res, sizeof(res));
+    char* buf = (char*) args->arg1;
+    int buf_size = (int) args->arg2;
+    int* size = (void*) args->arg3;
+    *size = get_module_info(name, buf, buf_size);
     args->skip_origin = 1;
 }
 
 void before_sukisu_kpm_version(hook_fargs3_t* args, void* udata) {
-    char __user* out = (char __user*) args->arg0;
-    unsigned int outlen = (unsigned int) args->arg1;
-    void __user* result = (void*) args->arg2;
-    char buffer[256] = {0};
-
+    char * buf = (char *) args->arg0;
+    int buf_size =  (int) args->arg1;
     const char *buildtime = get_build_time();
 
-    snprintf(buffer, sizeof(buffer)-1, "%d (%s)", kpver, buildtime);
-
-    int len = strlen(buffer);
-    if (len >= outlen) len = outlen - 1;
-    int rc = compat_copy_to_user(out, buffer, len + 1);
-    int res = (int) rc;
-
-    compat_copy_to_user(result, &res, sizeof(res));
+    snprintf(buf, buf_size-1, "%d (%s)", kpver, buildtime);
     args->skip_origin = 1;
 }
 
-
 void before_sukisu_kpm_control(hook_fargs3_t* args, void* udata) {
-    char __user* name = (char __user*) args->arg0;
-    char __user* arg = (char __user*) args->arg1;
-    void __user* result = (void*) args->arg2;
-    int res = (int) call_kpm_control(name, arg, NULL, 0);
+    const char * name = (const char *) args->arg0;
+    const char * arg = (const char *) args->arg1;
+    long arg_len = (long) args->arg2;
+    int * result = (void*) args->arg3;
+    int res = (int) call_kpm_control(name, arg, arg_len, NULL, 0);
 
-    compat_copy_to_user(result, &res, sizeof(res));
+    *result = res;
     args->skip_origin = 1;
 }
 


### PR DESCRIPTION
This PR removes the code that interacts with user-space memory from the kernel patch, making `sukisu_kpm_xxaction` a pure kernel method that only interacts with the kernel buffer.

Requires https://github.com/SukiSU-Ultra/SukiSU-Ultra/pull/539